### PR TITLE
Add new option to display the hyperbolic and non-hyperbolic parts of the form over the rational numbers

### DIFF
--- a/a1-degree.sage
+++ b/a1-degree.sage
@@ -22,6 +22,64 @@ f = ((x[0]-1)*x[0]*x[1],2*x[0]^2-3*x[1]^2); # INPUT: choose morphism; variables 
 p = (x[0]-1,2-3*x[1]^2); # INPUT: choose local point; set p = (1) for global computation
 diagonal = True; # INPUT: True prints out diagonal form (does not work in characteristic 2)
 details = False; # INPUT: True prints out invariants of bilinear form
+reduce_over_Q = False; # INPUT: True prints out reduction of the form over the rationals into hyperbolic and non-hyperbolic parts
+
+# Turn a diagonal matrix into a list of its diagonal entries
+def diagonal_matrix_to_list(M):
+    list_of_entries = []
+    for i in range(0,M.nrows()):
+        list_of_entries.append(M[i,i])
+    return(list_of_entries)
+
+# Find the squarefree part of an integer
+def strip_squares_integer(n):
+    factorization = list(factor(n))
+    reduced_factorization = []
+    for pair in factorization:
+        newpower = pair[1] % 2
+        reduced_factorization.append([pair[0],newpower])
+    
+    m = factor(n).unit()
+    for pair in reduced_factorization:
+        m = m*(pair[0]**pair[1])
+    return(m)
+
+# Find a rational number modulo squares 
+def strip_squares_rational(q):
+    a = q.numerator()
+    b = q.denominator()
+    n = a*b
+    return strip_squares_integer(n)
+
+
+# Match elements with their negatives into hyperbolic forms
+def hyp_list(list_of_diagonal_entries):
+    how_many_hyperbolics = 0
+    leftover_stuff = []
+    while list_of_diagonal_entries:
+        x = list_of_diagonal_entries[0]
+        y = -x
+        if y in list_of_diagonal_entries:
+            how_many_hyperbolics = how_many_hyperbolics + 1
+            
+            # Remove y from list
+            del list_of_diagonal_entries[list_of_diagonal_entries.index(y)]
+        else:
+            leftover_stuff.append(x)
+        # Remove x from list
+        del list_of_diagonal_entries[0]
+    
+    return('Rational reduction: ' +str(how_many_hyperbolics) + 'H + ' + str(leftover_stuff))
+
+# Take a diagonal matrix over Q and output its hyperbolic parts
+def reduce_matrix(M):
+    list_of_entries = diagonal_matrix_to_list(M)
+    reduced_list_of_entries = []
+    for q in list_of_entries:
+        w = strip_squares_rational(q)
+        reduced_list_of_entries.append(w)
+    return(hyp_list(reduced_list_of_entries))
+
 
 
 
@@ -116,3 +174,9 @@ if details: # (note: prints relevant invariants)
         for q in primes_first_n(1000): # (note: prints non-trivial Hasse-Witt invariants for first 1000 primes)
             if not QuadraticForm(M).hasse_invariant(q) == 1:
                 print(q,QuadraticForm(M).hasse_invariant(q))
+
+if reduce_over_Q:
+	QMat = QuadraticForm(M).rational_diagonal_form()
+	MMat = QMat.Gram_matrix()
+	print(reduce_matrix(MMat))
+


### PR DESCRIPTION
Added a new boolean `reduce_over_Q` which outputs the reduction of the form in the rationals, breaking it into its hyperbolic and non-hyperbolic parts. This is done by reducing each entry on the diagonal mod squares, then pairing off elements on the diagonal with their negatives. For example in the default function `f = ((x[0]-1)*x[0]*x[1],2*x[0]^2-3*x[1]^2);`, the option `reduce_over_Q = True;` will yield the following output:

```
Local A^1-degree of (x0^2*x1 - x0*x1, 2*x0^2 - 3*x1^2) at (x0 - 1, -3*x1^2 + 2)
Quadratic form in 2 variables over Rational Field with coefficients: 
[ -3/2 0 ]
[ * -1 ]
Rational reduction: 0H + [-6, -1]
```